### PR TITLE
feat: create short URL domain model

### DIFF
--- a/src/main/java/com/cleoaguiar/urlshorteningservice/domain/entity/ShortUrl.java
+++ b/src/main/java/com/cleoaguiar/urlshorteningservice/domain/entity/ShortUrl.java
@@ -1,0 +1,70 @@
+package com.cleoaguiar.urlshorteningservice.domain.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+
+import java.time.Instant;
+
+@Entity
+@Table(
+        name = "shortened_urls",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_shortened_urls_short_code",
+                        columnNames = "short_code"
+                )
+        }
+)
+
+public class ShortUrl {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "original_url", nullable = false, columnDefinition = "TEXT")
+    private String originalUrl;
+
+    @Column(name = "short_code", nullable = false, unique = true, length = 20)
+    private String shortCode;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+
+    @Column(name = "access_count", nullable = false)
+    private Long accessCount;
+
+    protected ShortUrl() {
+
+    }
+
+    public ShortUrl(String originalUrl, String shortCode) {
+        this.originalUrl = originalUrl;
+        this.shortCode = shortCode;
+    }
+
+    @PrePersist
+    private void prePersist() {
+        Instant now = Instant.now();
+        this.createdAt = now;
+        this.updatedAt = now;
+    }
+
+    @PreUpdate
+    private void preUpdate() {
+        this.updatedAt = Instant.now();
+    }
+
+    public void updateOriginalUrl(String originalUrl) {
+        this.originalUrl = originalUrl;
+    }
+}

--- a/src/main/java/com/cleoaguiar/urlshorteningservice/domain/repository/ShortUrlRepository.java
+++ b/src/main/java/com/cleoaguiar/urlshorteningservice/domain/repository/ShortUrlRepository.java
@@ -1,0 +1,8 @@
+package com.cleoaguiar.urlshorteningservice.domain.repository;
+
+import com.cleoaguiar.urlshorteningservice.domain.entity.ShortUrl;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ShortUrlRepository extends JpaRepository<ShortUrl, Long> {
+
+}


### PR DESCRIPTION
## Description

This PR creates the domain entity responsible for representing shortened URLs and mapping their persistent data to PostgreSQL.

The entity stores the original URL, its generated short code, and the timestamps used to track record creation and updates.

## Changes

* Created the `ShortUrl` domain entity.
* Added an auto-generated unique identifier.
* Added fields for the original URL and generated short code.
* Added creation and update timestamps.
* Mapped the entity to the existing database table.
* Defined required fields using non-null constraints.
* Added a unique constraint to prevent duplicate short codes.
* Configured automatic timestamp handling during persistence and updates.

## Validation

* The application starts successfully with Hibernate schema validation enabled.
* The entity mapping is compatible with the PostgreSQL schema created by Flyway.
* Required fields are mapped as non-nullable.
* Duplicate short codes are prevented by the database constraint.
* The project builds successfully with Maven.

## How to test

1. Make sure PostgreSQL is running and the required environment variables are configured.
2. Run the application:

```bash
./mvnw spring-boot:run
```

3. Verify that Hibernate validates the entity mapping without schema errors.
4. Run the project verification:

```bash
./mvnw clean verify
```

## Related issue

Closes #4
